### PR TITLE
add --impure option

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "shells",
   "displayName": "Shells - Nix Flake Environment Switcher",
   "description": "Switch development environment to Nix flake-based environment",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "icon": "icon.png",
   "engines": {
     "vscode": "^1.85.0"
@@ -45,6 +45,11 @@
           "type": "string",
           "default": "",
           "description": "Path to the flake.nix file (relative to workspace root). Leave empty to auto-detect."
+        },
+        "shells.impure": {
+          "type": "boolean",
+          "default": false,
+          "description": "allow impure environment (nix develop --impure)"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,12 @@
         "shells.impure": {
           "type": "boolean",
           "default": false,
-          "description": "allow impure environment (nix develop --impure)"
+          "description": "Allow impure flake evaluation (nix develop --impure)."
+        },
+        "shells.nixCommandExtraFlags": {
+          "type": "array",
+          "default": [],
+          "description": "Additional flags can be added via this option (e.g. ['--impure', '--fallback', '--refresh'])."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,13 +62,17 @@ async function isNixAvailable(): Promise<boolean> {
  * Securely extracts environment variables from nix develop
  */
 function getFlakeEnvironment(flakeDir: string): Promise<NodeJS.ProcessEnv> {
+	const config = vscode.workspace.getConfiguration('shells');
+	const impure = config.get<boolean>('impure');
+	const args = (impure) ? ['develop', flakeDir, '--impure', '--command', 'env'] : ['develop', flakeDir, '--command', 'env']
+
 	return new Promise((resolve, reject) => {
 		const env: NodeJS.ProcessEnv = {};
 		
-		outputChannel.appendLine(`[${new Date().toISOString()}] Running: nix develop ${flakeDir} --command env`);
+		outputChannel.appendLine(`[${new Date().toISOString()}] Running: nix develop ${flakeDir} ${(impure) ? '--impure' : ''} --command env`);
 		outputChannel.appendLine('='.repeat(80));
 		
-		const proc = spawn('nix', ['develop', flakeDir, '--command', 'env'], {
+		const proc = spawn('nix', args, {
 			cwd: flakeDir,
 			timeout: 60000, // 60 second timeout
 		});


### PR DESCRIPTION
Hello Konstantin Unruh,
Thank you for this good extension. It really ease the workflow using nix flake on vscode. Some of mine development environments require a little sacrifice on the "pure evaluation mode", so I added an additional setting to control `--impure` flag. 
How do you think about that? Can we add this option officially, I believe some use cases will benefit from this option (especially when using devenv).

edit: I think the extraFlags option would be great too. Added commit to realize that.